### PR TITLE
[Feat/#74] 동적 메타태그 페이지마다 적용

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,20 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,400,1,0"
     />
+    <meta name="title" property="og:title" content="It's me?!" />
+    <meta property="og:type" content="website" />
+    <meta
+      name="description"
+      property="og:description"
+      content="친구들의 답변으로 닮은 캐릭터를 만들어줘요!"
+    />
+    <meta
+      name="image"
+      property="og:image"
+      content="https://i.postimg.cc/HWZ9LPN2/It-s-me.png"
+    />
+    <!-- 나중에 배포한 url 넣기 -->
+    <meta name="url" property="og:url" content="" />
   </head>
   <body>
     <div id="root"></div>

--- a/src/pages/AnswerPage.tsx
+++ b/src/pages/AnswerPage.tsx
@@ -15,8 +15,11 @@ const setMetaTags = ({
   description = '친구들의 답변으로 닮은 캐릭터를 만들어줘요!', // 기본 설명
   imageUrl = 'https://i.postimg.cc/HWZ9LPN2/It-s-me.png', // 기본 사이트 이미지 경로
 }) => {
-  const titleTag = document.querySelector('meta[property="og:title"]');
+  const titleTag = document.querySelector('meta[property="og:title"]'); // document.querySelector를 사용하여 index.html의 해당 메타 태그를 선택
+
+  // 해당하는 메타 태그가 없다면 document.querySelector는 null을 반환하게 되고, 그러고 .setAttribute 메서드를 호출하려 하면 오류가 발생
   if (titleTag) {
+    // 따라서 if문으로 메타 태그가 존재하는지 확인한 후에 .setAttribute를 호출해야 함
     titleTag.setAttribute('content', `${title}`);
   }
 

--- a/src/pages/AnswerPage.tsx
+++ b/src/pages/AnswerPage.tsx
@@ -10,6 +10,34 @@ import NickNameInput from '../components/Input/NickNameInput';
 import { userStore } from '../stores/userStore';
 import { taskIdStore } from '../stores/taskId';
 
+const setMetaTags = ({
+  title = "It's me?!", // 기본 타이틀
+  description = '친구들의 답변으로 닮은 캐릭터를 만들어줘요!', // 기본 설명
+  imageUrl = 'https://i.postimg.cc/HWZ9LPN2/It-s-me.png', // 기본 사이트 이미지 경로
+}) => {
+  const titleTag = document.querySelector('meta[property="og:title"]');
+  if (titleTag) {
+    titleTag.setAttribute('content', `${title}`);
+  }
+
+  const descriptionTag = document.querySelector(
+    'meta[property="og:description"]'
+  );
+  if (descriptionTag) {
+    descriptionTag.setAttribute('content', description);
+  }
+
+  const imageTag = document.querySelector('meta[property="og:image"]');
+  if (imageTag) {
+    imageTag.setAttribute('content', imageUrl);
+  }
+
+  const urlTag = document.querySelector('meta[property="og:url"]');
+  if (urlTag) {
+    urlTag.setAttribute('content', window.location.href);
+  }
+};
+
 export default function AnswerPage() {
   const [questions, setQuestions] = useState([]);
   const [value, setValue] = useState<string[]>([]);
@@ -38,6 +66,11 @@ export default function AnswerPage() {
       }
     };
     getQuestions();
+    setMetaTags({
+      title: "It's me?! 질문 list",
+      description: '친구가 질문에 답변해주기를 요청하고 있어요!',
+      imageUrl: 'https://i.postimg.cc/HWZ9LPN2/It-s-me.png', // 배포하고나서 이미지 url 바꿔주기 // 일단 메인페이지 이미지 넣어놈
+    });
     if (nick == '') {
       setModalOpen(true);
     }

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -34,8 +34,11 @@ const setMetaTags = ({
   description = '친구들의 답변으로 닮은 캐릭터를 만들어줘요!', // 기본 설명
   imageUrl = 'https://i.postimg.cc/HWZ9LPN2/It-s-me.png', // 기본 사이트 이미지 경로
 }) => {
-  const titleTag = document.querySelector('meta[property="og:title"]');
+  const titleTag = document.querySelector('meta[property="og:title"]'); // document.querySelector를 사용하여 index.html의 해당 메타 태그를 선택
+
+  // 해당하는 메타 태그가 없다면 document.querySelector는 null을 반환하게 되고, 그러고 .setAttribute 메서드를 호출하려 하면 오류가 발생
   if (titleTag) {
+    // 따라서 if문으로 메타 태그가 존재하는지 확인한 후에 .setAttribute를 호출해야 함
     titleTag.setAttribute('content', `${title}`);
   }
 

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -2,6 +2,7 @@ import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import Button from '../components/Btn/Btn';
 import { keyframes } from 'styled-components';
+import { useEffect } from 'react';
 
 // 애니메이션 효과 왜 적용 안되는 지는 나중에,,,
 // 위치 변경 애니메이션
@@ -28,7 +29,42 @@ const StyledImg = styled.img`
   }
 `;
 
+const setMetaTags = ({
+  title = "It's me?!", // 기본 타이틀
+  description = '친구들의 답변으로 닮은 캐릭터를 만들어줘요!', // 기본 설명
+  imageUrl = 'https://i.postimg.cc/HWZ9LPN2/It-s-me.png', // 기본 사이트 이미지 경로
+}) => {
+  const titleTag = document.querySelector('meta[property="og:title"]');
+  if (titleTag) {
+    titleTag.setAttribute('content', `${title}`);
+  }
+
+  const descriptionTag = document.querySelector(
+    'meta[property="og:description"]'
+  );
+  if (descriptionTag) {
+    descriptionTag.setAttribute('content', description);
+  }
+
+  const imageTag = document.querySelector('meta[property="og:image"]');
+  if (imageTag) {
+    imageTag.setAttribute('content', imageUrl);
+  }
+
+  const urlTag = document.querySelector('meta[property="og:url"]');
+  if (urlTag) {
+    urlTag.setAttribute('content', window.location.href);
+  }
+};
+
 export default function MainPage() {
+  useEffect(() => {
+    setMetaTags({
+      title: "It's me?!",
+      description: '친구들의 답변으로 닮은 캐릭터를 만들어줘요!',
+      imageUrl: 'https://i.postimg.cc/HWZ9LPN2/It-s-me.png', // 배포하고나서 이미지 url 바꿔주기
+    });
+  });
   return (
     <Container>
       <BackLayout>

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -14,6 +14,34 @@ interface Character {
   nick_name: string;
 }
 
+const setMetaTags = ({
+  title = "It's me?!", // 기본 타이틀
+  description = '친구들의 답변으로 닮은 캐릭터를 만들어줘요!', // 기본 설명
+  imageUrl = 'https://i.postimg.cc/HWZ9LPN2/It-s-me.png', // 기본 사이트 이미지 경로
+}) => {
+  const titleTag = document.querySelector('meta[property="og:title"]');
+  if (titleTag) {
+    titleTag.setAttribute('content', `${title}`);
+  }
+
+  const descriptionTag = document.querySelector(
+    'meta[property="og:description"]'
+  );
+  if (descriptionTag) {
+    descriptionTag.setAttribute('content', description);
+  }
+
+  const imageTag = document.querySelector('meta[property="og:image"]');
+  if (imageTag) {
+    imageTag.setAttribute('content', imageUrl);
+  }
+
+  const urlTag = document.querySelector('meta[property="og:url"]');
+  if (urlTag) {
+    urlTag.setAttribute('content', window.location.href);
+  }
+};
+
 export default function MyPage() {
   const [characters, setCharacters] = useState<Character[]>([]);
   const { userId, nickName } = userStore();
@@ -35,6 +63,11 @@ export default function MyPage() {
 
   useEffect(() => {
     getChar();
+    setMetaTags({
+      title: "It's me?! 마이페이지",
+      description: '친구들이 만들어준 캐릭터들을 확인해보세요!',
+      imageUrl: 'https://i.postimg.cc/HWZ9LPN2/It-s-me.png', // 배포하고나서 이미지 url 바꿔주기 // 일단 메인페이지 이미지 넣어놈
+    });
   }, []);
 
   return (

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -19,8 +19,11 @@ const setMetaTags = ({
   description = '친구들의 답변으로 닮은 캐릭터를 만들어줘요!', // 기본 설명
   imageUrl = 'https://i.postimg.cc/HWZ9LPN2/It-s-me.png', // 기본 사이트 이미지 경로
 }) => {
-  const titleTag = document.querySelector('meta[property="og:title"]');
+  const titleTag = document.querySelector('meta[property="og:title"]'); // document.querySelector를 사용하여 index.html의 해당 메타 태그를 선택
+
+  // 해당하는 메타 태그가 없다면 document.querySelector는 null을 반환하게 되고, 그러고 .setAttribute 메서드를 호출하려 하면 오류가 발생
   if (titleTag) {
+    // 따라서 if문으로 메타 태그가 존재하는지 확인한 후에 .setAttribute를 호출해야 함
     titleTag.setAttribute('content', `${title}`);
   }
 


### PR DESCRIPTION
## 📖개요
<br>
// 메인페이지 메타태그 적용 모습
<img width="959" alt="스크린샷 2023-07-26 오후 2 34 37" src="https://github.com/2023-Summer-Bootcamp-Team-G/frontend/assets/121246589/110d076d-7f10-4e20-b6a7-ab15aeac76da">
<br>
// 질문페이지 메타태그 적용 모습
<img width="941" alt="스크린샷 2023-07-26 오후 3 33 30" src="https://github.com/2023-Summer-Bootcamp-Team-G/frontend/assets/121246589/eb1341cc-4e28-4c9b-9d75-8f9bc5d09439">

// 마이페이지 메타태그 적용 모습
<img width="941" alt="스크린샷 2023-07-26 오후 3 33 12" src="https://github.com/2023-Summer-Bootcamp-Team-G/frontend/assets/121246589/fd2bddcf-0ce0-434e-aa56-c7e4d4b61ba5">

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #74 
<br>
<br>

## 💻작업사항
- 메인페이지, 마이페이지, 질문페이지 페이지마다 동적 메타태그 적용
- 추후 배포 후에 이미지, url 확인해가며 다르게 설정해주기(현재는 타이틀, 설명 제외 나머지는 임시로 메인으로 다 설정함)
<br>



## 💡작성한 이슈 외에 작업한 사항
-
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [x] 코드 리뷰해주세용

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
